### PR TITLE
Use DbContextFactory for scoped db contexts

### DIFF
--- a/Components/CalendarMonth.razor.cs
+++ b/Components/CalendarMonth.razor.cs
@@ -15,8 +15,8 @@ public partial class CalendarMonth
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
 
-	[Inject]
-	private ApplicationDbContext Db { get; set; } = default!;
+        [Inject]
+        private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
 
 	[Inject]
 	private Services.SlotService Slots { get; set; } = default!;
@@ -63,15 +63,17 @@ public partial class CalendarMonth
 	{
 		_eventsByDay.Clear();
 
-		var rangeStart = Month.ToDateTime(new TimeOnly(0, 0), DateTimeKind.Local);
-		var rangeEnd = rangeStart.AddMonths(1);
+                var rangeStart = Month.ToDateTime(new TimeOnly(0, 0), DateTimeKind.Local);
+                var rangeEnd = rangeStart.AddMonths(1);
 
-		var apps = await Db.Appointments
-			.Where(a => a.OwnerUserId == OwnerUserId &&
-						a.StartUtc >= rangeStart.ToUniversalTime() &&
-						a.StartUtc < rangeEnd.ToUniversalTime())
-			.OrderBy(a => a.StartUtc)
-			.ToListAsync();
+                await using var db = await DbFactory.CreateDbContextAsync();
+
+                var apps = await db.Appointments
+                        .Where(a => a.OwnerUserId == OwnerUserId &&
+                                                a.StartUtc >= rangeStart.ToUniversalTime() &&
+                                                a.StartUtc < rangeEnd.ToUniversalTime())
+                        .OrderBy(a => a.StartUtc)
+                        .ToListAsync();
 
 		foreach (var a in apps)
 		{

--- a/Components/CalendarMonth.razor.cs
+++ b/Components/CalendarMonth.razor.cs
@@ -15,8 +15,8 @@ public partial class CalendarMonth
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
 
-        [Inject]
-        private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
+	[Inject]
+	private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
 
 	[Inject]
 	private Services.SlotService Slots { get; set; } = default!;
@@ -63,17 +63,17 @@ public partial class CalendarMonth
 	{
 		_eventsByDay.Clear();
 
-                var rangeStart = Month.ToDateTime(new TimeOnly(0, 0), DateTimeKind.Local);
-                var rangeEnd = rangeStart.AddMonths(1);
+		var rangeStart = Month.ToDateTime(new TimeOnly(0, 0), DateTimeKind.Local);
+		var rangeEnd = rangeStart.AddMonths(1);
 
-                await using var db = await DbFactory.CreateDbContextAsync();
+		await using var db = await DbFactory.CreateDbContextAsync();
 
-                var apps = await db.Appointments
-                        .Where(a => a.OwnerUserId == OwnerUserId &&
-                                                a.StartUtc >= rangeStart.ToUniversalTime() &&
-                                                a.StartUtc < rangeEnd.ToUniversalTime())
-                        .OrderBy(a => a.StartUtc)
-                        .ToListAsync();
+		var apps = await db.Appointments
+				.Where(a => a.OwnerUserId == OwnerUserId &&
+					a.StartUtc >= rangeStart.ToUniversalTime() &&
+					a.StartUtc < rangeEnd.ToUniversalTime())
+				.OrderBy(a => a.StartUtc)
+				.ToListAsync();
 
 		foreach (var a in apps)
 		{

--- a/Pages/Index.razor.cs
+++ b/Pages/Index.razor.cs
@@ -3,6 +3,7 @@ using Meetify.Domain;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 
 namespace Meetify.Pages;
 
@@ -16,8 +17,8 @@ public partial class Index
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
 
-        [Inject]
-        private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
+	[Inject]
+	private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
 
 	[CascadingParameter]
 	private Task<AuthenticationState> AuthTask { get; set; } = default!;
@@ -34,11 +35,11 @@ public partial class Index
 
 		if (userEmail is null) return;
 
-                var link = new ShareLink { OwnerUserId = userEmail };
+		var link = new ShareLink { OwnerUserId = userEmail };
 
-                await using var db = await DbFactory.CreateDbContextAsync();
-                db.ShareLinks.Add(link);
-                await db.SaveChangesAsync();
+		await using var db = await DbFactory.CreateDbContextAsync();
+		db.ShareLinks.Add(link);
+		await db.SaveChangesAsync();
 
 		_newLink = Nav.BaseUri.TrimEnd('/') + $"/s/{link.Id}";
 	}

--- a/Pages/Index.razor.cs
+++ b/Pages/Index.razor.cs
@@ -16,8 +16,8 @@ public partial class Index
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
 
-	[Inject]
-	private ApplicationDbContext Db { get; set; } = default!;
+        [Inject]
+        private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
 
 	[CascadingParameter]
 	private Task<AuthenticationState> AuthTask { get; set; } = default!;
@@ -34,10 +34,11 @@ public partial class Index
 
 		if (userEmail is null) return;
 
-		var link = new ShareLink { OwnerUserId = userEmail };
+                var link = new ShareLink { OwnerUserId = userEmail };
 
-		Db.ShareLinks.Add(link);
-		await Db.SaveChangesAsync();
+                await using var db = await DbFactory.CreateDbContextAsync();
+                db.ShareLinks.Add(link);
+                await db.SaveChangesAsync();
 
 		_newLink = Nav.BaseUri.TrimEnd('/') + $"/s/{link.Id}";
 	}

--- a/Pages/Schedule.razor.cs
+++ b/Pages/Schedule.razor.cs
@@ -34,11 +34,8 @@ public partial class Schedule
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
 
-	[Inject]
-	private ApplicationDbContext Db { get; set; } = default!;
-
-	[Inject]
-	private Services.SlotService Slots { get; set; } = default!;
+        [Inject]
+        private Services.SlotService Slots { get; set; } = default!;
 
 	[Inject] 
 	private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
@@ -54,10 +51,11 @@ public partial class Schedule
 		return base.OnInitializedAsync();
 	}
 
-	protected override async Task OnParametersSetAsync()
-	{
-		_link = await Db.ShareLinks.FindAsync(Id);
-		if (_link is null) { _message = "Odkaz je neplatný."; return; }
+        protected override async Task OnParametersSetAsync()
+        {
+                await using var db = await DbFactory.CreateDbContextAsync();
+                _link = await db.ShareLinks.FindAsync(Id);
+                if (_link is null) { _message = "Odkaz je neplatný."; return; }
 
 		_linkOwner = _link.OwnerUserId;
 		if (_linkOwner is null) { _message = "Kalendář nenalezen."; return; }

--- a/Pages/Schedule.razor.cs
+++ b/Pages/Schedule.razor.cs
@@ -4,8 +4,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using System;
-using static System.Reflection.Metadata.BlobBuilder;
 
 namespace Meetify.Pages;
 
@@ -34,10 +32,10 @@ public partial class Schedule
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
 
-        [Inject]
-        private Services.SlotService Slots { get; set; } = default!;
+	[Inject]
+	private Services.SlotService Slots { get; set; } = default!;
 
-	[Inject] 
+	[Inject]
 	private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
 
 	[CascadingParameter]
@@ -51,11 +49,11 @@ public partial class Schedule
 		return base.OnInitializedAsync();
 	}
 
-        protected override async Task OnParametersSetAsync()
-        {
-                await using var db = await DbFactory.CreateDbContextAsync();
-                _link = await db.ShareLinks.FindAsync(Id);
-                if (_link is null) { _message = "Odkaz je neplatný."; return; }
+	protected override async Task OnParametersSetAsync()
+	{
+		await using var db = await DbFactory.CreateDbContextAsync();
+		_link = await db.ShareLinks.FindAsync(Id);
+		if (_link is null) { _message = "Odkaz je neplatný."; return; }
 
 		_linkOwner = _link.OwnerUserId;
 		if (_linkOwner is null) { _message = "Kalendář nenalezen."; return; }

--- a/Services/GoogleUserService.cs
+++ b/Services/GoogleUserService.cs
@@ -6,25 +6,27 @@ namespace Meetify.Services;
 
 public class GoogleUserService
 {
-	private readonly ApplicationDbContext _db;
+        private readonly IDbContextFactory<ApplicationDbContext> _dbFactory;
 
-	public GoogleUserService(ApplicationDbContext db) => _db = db;
+        public GoogleUserService(IDbContextFactory<ApplicationDbContext> dbFactory) => _dbFactory = dbFactory;
 
 	public async Task<GoogleUser?> GetByEmailAsync(string email, CancellationToken ct = default)
 	{
-		var norm = Normalize(email);
-		return await _db.GoogleUsers.AsNoTracking()
-			.FirstOrDefaultAsync(x => x.Email == norm, ct);
+                await using var db = await _dbFactory.CreateDbContextAsync();
+                var norm = Normalize(email);
+                return await db.GoogleUsers.AsNoTracking()
+                        .FirstOrDefaultAsync(x => x.Email == norm, ct);
 	}
 
 	public async Task<GoogleUser> UpsertFromClaimsAsync(
 		string email, string? firstName, string? lastName, string? identityUserId = null,
 		CancellationToken ct = default)
 	{
-		var norm = Normalize(email);
+                await using var db = await _dbFactory.CreateDbContextAsync();
+                var norm = Normalize(email);
 
-		var entity = await _db.GoogleUsers
-			.FirstOrDefaultAsync(x => x.Email == norm, ct);
+                var entity = await db.GoogleUsers
+                        .FirstOrDefaultAsync(x => x.Email == norm, ct);
 
 		if (entity is null)
 		{
@@ -37,7 +39,7 @@ public class GoogleUserService
 				CreatedUtc = DateTime.UtcNow,
 				UpdatedUtc = DateTime.UtcNow
 			};
-			_db.GoogleUsers.Add(entity);
+                        db.GoogleUsers.Add(entity);
 		}
 		else
 		{
@@ -49,7 +51,7 @@ public class GoogleUserService
 			entity.UpdatedUtc = DateTime.UtcNow;
 		}
 
-		await _db.SaveChangesAsync(ct);
+                await db.SaveChangesAsync(ct);
 		return entity;
 	}
 

--- a/Services/GoogleUserService.cs
+++ b/Services/GoogleUserService.cs
@@ -6,27 +6,27 @@ namespace Meetify.Services;
 
 public class GoogleUserService
 {
-        private readonly IDbContextFactory<ApplicationDbContext> _dbFactory;
+	private readonly IDbContextFactory<ApplicationDbContext> _dbFactory;
 
-        public GoogleUserService(IDbContextFactory<ApplicationDbContext> dbFactory) => _dbFactory = dbFactory;
+	public GoogleUserService(IDbContextFactory<ApplicationDbContext> dbFactory) => _dbFactory = dbFactory;
 
 	public async Task<GoogleUser?> GetByEmailAsync(string email, CancellationToken ct = default)
 	{
-                await using var db = await _dbFactory.CreateDbContextAsync();
-                var norm = Normalize(email);
-                return await db.GoogleUsers.AsNoTracking()
-                        .FirstOrDefaultAsync(x => x.Email == norm, ct);
+		await using var db = await _dbFactory.CreateDbContextAsync();
+		var norm = Normalize(email);
+		return await db.GoogleUsers.AsNoTracking()
+				.FirstOrDefaultAsync(x => x.Email == norm, ct);
 	}
 
 	public async Task<GoogleUser> UpsertFromClaimsAsync(
 		string email, string? firstName, string? lastName, string? identityUserId = null,
 		CancellationToken ct = default)
 	{
-                await using var db = await _dbFactory.CreateDbContextAsync();
-                var norm = Normalize(email);
+		await using var db = await _dbFactory.CreateDbContextAsync();
+		var norm = Normalize(email);
 
-                var entity = await db.GoogleUsers
-                        .FirstOrDefaultAsync(x => x.Email == norm, ct);
+		var entity = await db.GoogleUsers
+				.FirstOrDefaultAsync(x => x.Email == norm, ct);
 
 		if (entity is null)
 		{
@@ -39,19 +39,21 @@ public class GoogleUserService
 				CreatedUtc = DateTime.UtcNow,
 				UpdatedUtc = DateTime.UtcNow
 			};
-                        db.GoogleUsers.Add(entity);
+			db.GoogleUsers.Add(entity);
 		}
 		else
 		{
 			// update latest details
 			entity.FirstName = string.IsNullOrWhiteSpace(firstName) ? entity.FirstName : firstName;
 			entity.LastName = string.IsNullOrWhiteSpace(lastName) ? entity.LastName : lastName;
+
 			if (!string.IsNullOrWhiteSpace(identityUserId))
 				entity.IdentityUserId = identityUserId;
+
 			entity.UpdatedUtc = DateTime.UtcNow;
 		}
 
-                await db.SaveChangesAsync(ct);
+		await db.SaveChangesAsync(ct);
 		return entity;
 	}
 

--- a/Services/SlotService.cs
+++ b/Services/SlotService.cs
@@ -7,40 +7,48 @@ namespace Meetify.Services;
 
 public class SlotService
 {
-	private readonly ApplicationDbContext _db;
-	private readonly TimeZoneInfo _tz; // Europe/Prague
+        private readonly IDbContextFactory<ApplicationDbContext> _dbFactory;
+        private readonly TimeZoneInfo _tz; // Europe/Prague
 
-	public SlotService(ApplicationDbContext db)
-	{
-		_db = db;
-		_tz = TimeZoneInfo.FindSystemTimeZoneById("Central Europe Standard Time"); // Windows ID pro Prahu
-	}
+        public SlotService(IDbContextFactory<ApplicationDbContext> dbFactory)
+        {
+                _dbFactory = dbFactory;
+                _tz = TimeZoneInfo.FindSystemTimeZoneById("Central Europe Standard Time"); // Windows ID pro Prahu
+        }
 
 	public static readonly TimeSpan DayStart = new(9, 0, 0);
 	public static readonly TimeSpan DayEnd = new(16, 0, 0);
 
-	public async Task<int> CountAppointmentsInMonthAsync(string ownerUserId, DateOnly month)
-	{
-		var start = month.ToDateTime(new(1, 0, 0), DateTimeKind.Unspecified);
-		var end = start.AddMonths(1);
-		return await _db.Appointments
-			.Where(a => a.OwnerUserId == ownerUserId && a.StartUtc >= start && a.StartUtc < end)
-			.CountAsync();
-	}
+        public async Task<int> CountAppointmentsInMonthAsync(string ownerUserId, DateOnly month)
+        {
+                await using var db = await _dbFactory.CreateDbContextAsync();
+                var start = month.ToDateTime(new(1, 0, 0), DateTimeKind.Unspecified);
+                var end = start.AddMonths(1);
+                return await db.Appointments
+                        .Where(a => a.OwnerUserId == ownerUserId && a.StartUtc >= start && a.StartUtc < end)
+                        .CountAsync();
+        }
 
-	public async Task<List<(DateTime startUtc, DateTime endUtc)>> GetExistingForDayAsync(string ownerUserId, DateOnly day)
-	{
-		var dayStartLocal = day.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
-		var dayEndLocal = dayStartLocal.AddDays(1);
-		var startUtc = TimeZoneInfo.ConvertTimeToUtc(dayStartLocal, _tz);
-		var endUtc = TimeZoneInfo.ConvertTimeToUtc(dayEndLocal, _tz);
+        public async Task<List<(DateTime startUtc, DateTime endUtc)>> GetExistingForDayAsync(string ownerUserId, DateOnly day)
+        {
+                await using var db = await _dbFactory.CreateDbContextAsync();
+                return await GetExistingForDayInternalAsync(db, ownerUserId, day);
+        }
 
-		return await _db.Appointments
-			.Where(a => a.OwnerUserId == ownerUserId && a.StartUtc >= startUtc && a.StartUtc < endUtc)
-			.OrderBy(a => a.StartUtc)
-			.Select(a => new ValueTuple<DateTime, DateTime>(a.StartUtc, a.EndUtc))
-			.ToListAsync();
-	}
+        private async Task<List<(DateTime startUtc, DateTime endUtc)>> GetExistingForDayInternalAsync(
+                ApplicationDbContext db, string ownerUserId, DateOnly day)
+        {
+                var dayStartLocal = day.ToDateTime(TimeOnly.MinValue, DateTimeKind.Unspecified);
+                var dayEndLocal = dayStartLocal.AddDays(1);
+                var startUtc = TimeZoneInfo.ConvertTimeToUtc(dayStartLocal, _tz);
+                var endUtc = TimeZoneInfo.ConvertTimeToUtc(dayEndLocal, _tz);
+
+                return await db.Appointments
+                        .Where(a => a.OwnerUserId == ownerUserId && a.StartUtc >= startUtc && a.StartUtc < endUtc)
+                        .OrderBy(a => a.StartUtc)
+                        .Select(a => new ValueTuple<DateTime, DateTime>(a.StartUtc, a.EndUtc))
+                        .ToListAsync();
+        }
 
 	public IEnumerable<TimeOnly> GenerateStartTimes(TimeSpan duration)
 	{
@@ -89,9 +97,9 @@ public class SlotService
 			return list;
 		}
 
-		var existing = (await GetExistingForDayAsync(ownerUserId, day))
-			.Select(x => (s: x.startUtc, e: x.endUtc))
-			.ToList();
+                var existing = (await GetExistingForDayAsync(ownerUserId, day))
+                        .Select(x => (s: x.startUtc, e: x.endUtc))
+                        .ToList();
 		var dailyOk = RespectsDailyLimit(existing);
 
 		foreach (var start in GenerateStartTimes(duration))
@@ -117,10 +125,12 @@ public class SlotService
 		string guestFirst,
 		string guestLast)
 	{
-		// Zkontrolovat odkaz
-		var link = await _db.ShareLinks.FirstOrDefaultAsync(l => l.Id == linkId && l.OwnerUserId == ownerUserId);
-		if (link is null) return (false, "Neplatný odkaz.");
-		if (link.IsUsed) return (false, "Tento odkaz už byl použit pro sjednání jedné schůzky.");
+                await using var db = await _dbFactory.CreateDbContextAsync();
+
+                // Zkontrolovat odkaz
+                var link = await db.ShareLinks.FirstOrDefaultAsync(l => l.Id == linkId && l.OwnerUserId == ownerUserId);
+                if (link is null) return (false, "Neplatný odkaz.");
+                if (link.IsUsed) return (false, "Tento odkaz už byl použit pro sjednání jedné schůzky.");
 
 		var today = DateOnly.FromDateTime(TimeZoneInfo.ConvertTime(DateTime.UtcNow, _tz).Date);
 		if (!IsWithinWindow(day, today) || IsWeekendOrHoliday(day))
@@ -131,33 +141,33 @@ public class SlotService
 		var startUtc = TimeZoneInfo.ConvertTimeToUtc(localStart, _tz);
 		var endUtc = TimeZoneInfo.ConvertTimeToUtc(localEnd, _tz);
 
-		// Re-validace proti aktuálním datům v DB v transakci
-		using var tx = await _db.Database.BeginTransactionAsync();
+                // Re-validace proti aktuálním datům v DB v transakci
+                await using var tx = await db.Database.BeginTransactionAsync();
 
-		var existing = await GetExistingForDayAsync(ownerUserId, day);
-		if (!RespectsDailyLimit(existing.Select(x => (x.startUtc, x.endUtc))))
-			return (false, "Na tento den je již maximum 3 schůzek.");
-		if (!FitsWithBuffer(startUtc, endUtc, existing.Select(x => (x.startUtc, x.endUtc))))
-			return (false, "Termín koliduje s jinou schůzkou nebo povinnou pauzou.");
+                var existing = await GetExistingForDayInternalAsync(db, ownerUserId, day);
+                if (!RespectsDailyLimit(existing.Select(x => (x.startUtc, x.endUtc))))
+                        return (false, "Na tento den je již maximum 3 schůzek.");
+                if (!FitsWithBuffer(startUtc, endUtc, existing.Select(x => (x.startUtc, x.endUtc))))
+                        return (false, "Termín koliduje s jinou schůzkou nebo povinnou pauzou.");
 
-		_db.Appointments.Add(new Appointment
-		{
-			OwnerUserId = ownerUserId,
-			StartUtc = startUtc,
-			EndUtc = endUtc,
-			GuestFirstName = guestFirst.Trim(),
-			GuestLastName = guestLast.Trim()
-		});
+                db.Appointments.Add(new Appointment
+                {
+                        OwnerUserId = ownerUserId,
+                        StartUtc = startUtc,
+                        EndUtc = endUtc,
+                        GuestFirstName = guestFirst.Trim(),
+                        GuestLastName = guestLast.Trim()
+                });
 
 		// zamknout odkaz (lze rezervovat pouze jednu schůzku tímto linkem)
-		link.IsUsed = true;
+                link.IsUsed = true;
 
-		try
-		{
-			await _db.SaveChangesAsync();
-			await tx.CommitAsync();
-			return (true, null);
-		}
+                try
+                {
+                        await db.SaveChangesAsync();
+                        await tx.CommitAsync();
+                        return (true, null);
+                }
 		catch (DbUpdateException)
 		{
 			await tx.RollbackAsync();


### PR DESCRIPTION
## Summary
- Replace direct `ApplicationDbContext` injections with `IDbContextFactory<ApplicationDbContext>`
- Create a fresh `ApplicationDbContext` per operation in components, services, and pages
- Ensure booking operations use single context/transaction per request

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b38622540c832b989e7ca8a3e2df3f