### PR TITLE
Add month change callback and sync Schedule calendar

### DIFF
--- a/Components/CalendarMonth.razor.cs
+++ b/Components/CalendarMonth.razor.cs
@@ -8,9 +8,10 @@ namespace Meetify.Components;
 public partial class CalendarMonth
 {
 	[Parameter] public DateOnly Month { get; set; }
-	[Parameter] public string OwnerUserId { get; set; } = default!;
-	[Parameter] public bool IsPublicView { get; set; }
-	[Parameter] public EventCallback<DateOnly> OnDayClick { get; set; }
+        [Parameter] public string OwnerUserId { get; set; } = default!;
+        [Parameter] public bool IsPublicView { get; set; }
+        [Parameter] public EventCallback<DateOnly> OnDayClick { get; set; }
+        [Parameter] public EventCallback<DateOnly> MonthChanged { get; set; }
 
 	[Inject]
 	private NavigationManager Nav { get; set; } = default!;
@@ -111,19 +112,21 @@ public partial class CalendarMonth
 			await OnDayClick.InvokeAsync(day);
 	}
 
-	public async Task PrevMonth()
-	{
-		Month = Month.AddMonths(-1);
-		BuildWeeks();
-		await LoadEvents();
-		StateHasChanged();
-	}
+        public async Task PrevMonth()
+        {
+                Month = Month.AddMonths(-1);
+                BuildWeeks();
+                await LoadEvents();
+                await MonthChanged.InvokeAsync(Month);
+                StateHasChanged();
+        }
 
-	public async Task NextMonth()
-	{
-		Month = Month.AddMonths(1);
-		BuildWeeks();
-		await LoadEvents();
-		StateHasChanged();
-	}
+        public async Task NextMonth()
+        {
+                Month = Month.AddMonths(1);
+                BuildWeeks();
+                await LoadEvents();
+                await MonthChanged.InvokeAsync(Month);
+                StateHasChanged();
+        }
 }

--- a/Pages/Schedule.razor
+++ b/Pages/Schedule.razor
@@ -11,7 +11,8 @@
     <h1 class="mb-3">Sjednat schůzku s uživatelem @OwnerLabel()</h1>
     <h2 class="mb-4">Počet schůzek v tomto měsíci: @_appointmentsCount</h2>
 
-    <CalendarMonth Month="_currentMonth"
+    <CalendarMonth @bind-Month="_currentMonth"
+                   @bind-Month:after="OnMonthChanged"
                    OwnerUserId="@_link.OwnerUserId"
                    IsPublicView="true"
                    OnDayClick="OpenDay" />

--- a/Pages/Schedule.razor.cs
+++ b/Pages/Schedule.razor.cs
@@ -98,13 +98,20 @@ public partial class Schedule
 		await ReloadSlots();
 	}
 
-	private async Task ReloadSlots()
-	{
-		var dur = int.Parse(_duration);
+        private async Task ReloadSlots()
+        {
+                var dur = int.Parse(_duration);
 
-		_slots = await Slots.GetSlotsAsync(_link!.OwnerUserId, _selectedDay, TimeSpan.FromMinutes(dur), Today);
-		StateHasChanged();
-	}
+                _slots = await Slots.GetSlotsAsync(_link!.OwnerUserId, _selectedDay, TimeSpan.FromMinutes(dur), Today);
+                StateHasChanged();
+        }
+
+        private async Task OnMonthChanged()
+        {
+                if (_link is null) return;
+                _appointmentsCount = await Slots.CountAppointmentsInMonthAsync(_link.OwnerUserId, _currentMonth);
+                StateHasChanged();
+        }
 
 	private async Task Book()
 	{


### PR DESCRIPTION
## Summary
- trigger `MonthChanged` event when navigating months in `CalendarMonth`
- bind `Schedule` calendar's month for two-way sync and update appointment count

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b42ad283a8832bbd88ca2ce87df3d2