### PR TITLE
Display Czech holiday names in calendar

### DIFF
--- a/Components/CalendarMonth.razor
+++ b/Components/CalendarMonth.razor
@@ -1,4 +1,5 @@
 ﻿@using Microsoft.AspNetCore.Identity
+@using Meetify.Services
 
 <div class="d-flex justify-content-between align-items-center mb-3">
     <div class="btn-group" role="group" aria-label="Month navigation">
@@ -39,7 +40,11 @@
                                 <small class="@($"text-muted {(muted ? "opacity-75" : "")}")">
                                     @day.Day.@day.Month.
                                 </small>
-                                @if (Services.SlotService.IsWeekendOrHoliday(day))
+                                @if (CzechHolidays.GetHolidayName(day) is string holiday)
+                                {
+                                    <span class="badge bg-secondary">@holiday</span>
+                                }
+                                else if (Services.SlotService.IsWeekendOrHoliday(day))
                                 {
                                     <span class="badge bg-secondary">volno</span>
                                 }

--- a/Services/SlotService.cs
+++ b/Services/SlotService.cs
@@ -49,13 +49,11 @@ public class SlotService
 				.ToListAsync();
 	}
 
-	public static bool IsWeekendOrHoliday(DateOnly d)
-	{
-		if (d.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday) return true;
-		//var set = CzechHolidays.ForYear(d.Year);
-		//return set.Contains(d);
-		return false;
-	}
+        public static bool IsWeekendOrHoliday(DateOnly d)
+        {
+                if (d.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday) return true;
+                return CzechHolidays.IsHoliday(d);
+        }
 
 	public static bool IsWithinWindow(DateOnly d, DateOnly today) =>
 		d > today && d <= today.AddMonths(2);

--- a/Services/SlotService.cs
+++ b/Services/SlotService.cs
@@ -49,11 +49,11 @@ public class SlotService
 				.ToListAsync();
 	}
 
-        public static bool IsWeekendOrHoliday(DateOnly d)
-        {
-                if (d.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday) return true;
-                return CzechHolidays.IsHoliday(d);
-        }
+	public static bool IsWeekendOrHoliday(DateOnly d)
+	{
+		if (d.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday) return true;
+		return CzechHolidays.IsHoliday(d);
+	}
 
 	public static bool IsWithinWindow(DateOnly d, DateOnly today) =>
 		d > today && d <= today.AddMonths(2);


### PR DESCRIPTION
## Summary
- Show specific Czech holiday names inside each calendar day instead of generic "volno".
- Recognize Czech public holidays when determining day availability.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4807d5804832b85a09f72adccb110