### PR TITLE
Remove Bootstrap bg-light from calendar cells

### DIFF
--- a/Components/CalendarMonth.razor
+++ b/Components/CalendarMonth.razor
@@ -32,7 +32,7 @@
                         var clickable = IsClickable(day);
                         var muted = !isCurrentMonth;
 
-                        <td class="@($"p-2 {(!isCurrentMonth ? "bg-light" : "")}")"
+                        <td class="@($"p-2 {(!isCurrentMonth ? "outside-month" : "")}")"
                             style="height: 110px; vertical-align: top; cursor:@(clickable ? "pointer" : "default")"
                             @onclick="(() => OnDayClickInternal(day))">
 

--- a/Components/CalendarMonth.razor
+++ b/Components/CalendarMonth.razor
@@ -57,13 +57,13 @@
                                     {
                                         if (IsPublicView)
                                         {
-                                            <span class="badge bg-secondary text-truncate" title="Obsazeno">
+                                            <span class="badge bg-secondary w-100 text-truncate d-block" title="Obsazeno">
                                                 Obsazeno
                                             </span>
                                         }
                                         else
                                         {
-                                            <span class="badge bg-primary text-truncate" title="@ev.text">
+                                            <span class="badge bg-primary w-100 text-truncate d-block" title="@ev.text">
                                                 @ev.text
                                             </span>
                                         }

--- a/Components/CalendarMonth.razor.css
+++ b/Components/CalendarMonth.razor.css
@@ -1,11 +1,14 @@
 .calendar {
     table-layout: fixed;
     width: 100%;
-    background-color: red;
 }
 
 .calendar td {
     width: calc(100% / 7); /* 7 days */
     overflow: hidden;
+}
+
+.calendar td.outside-month {
+    background-color: var(--bs-light-bg-subtle);
 }
 

--- a/Components/CalendarMonth.razor.css
+++ b/Components/CalendarMonth.razor.css
@@ -9,6 +9,12 @@
 }
 
 .calendar td.outside-month {
-    background-color: var(--bs-light-bg-subtle);
+    background-color: lightgray;
+}
+
+.calendar .badge {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
## Summary
- Eliminate `bg-light` on calendar day cells and use a custom `outside-month` class.
- Style calendar cells directly in `CalendarMonth.razor.css`, including a light background for non-current-month days.

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 error when attempting to install dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b5593359fc832b978bc2a988642713