### PR TITLE
Forward auth cookie for SignalR hub connections

### DIFF
--- a/Components/CalendarMonth.razor.cs
+++ b/Components/CalendarMonth.razor.cs
@@ -2,6 +2,7 @@ using Meetify.Data;
 using Meetify.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 
 namespace Meetify.Components;
@@ -24,8 +25,11 @@ public partial class CalendarMonth : IAsyncDisposable
 	[Parameter] public EventCallback<DateOnly> OnDayClick { get; set; }
 	[Parameter] public EventCallback<DateOnly> OnMonthChanged { get; set; }
 
-	[Inject]
-	private NavigationManager Nav { get; set; } = default!;
+        [Inject]
+        private NavigationManager Nav { get; set; } = default!;
+
+        [Inject]
+        private IHttpContextAccessor HttpContextAccessor { get; set; } = default!;
 
 	[Inject]
 	private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
@@ -38,7 +42,12 @@ public partial class CalendarMonth : IAsyncDisposable
                 if (!IsPublicView)
                 {
                         _hubConnection = new HubConnectionBuilder()
-                                .WithUrl(Nav.ToAbsoluteUri("/hubs/appointments"))
+                                .WithUrl(Nav.ToAbsoluteUri("/hubs/appointments"), options =>
+                                {
+                                        var cookie = HttpContextAccessor.HttpContext?.Request.Headers["Cookie"];
+                                        if (!string.IsNullOrEmpty(cookie))
+                                                options.Headers.Add("Cookie", cookie.ToString());
+                                })
                                 .WithAutomaticReconnect()
                                 .Build();
 

--- a/Program.cs
+++ b/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddControllers();
 builder.Services.AddSignalR();
+builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddScoped<SlotService>();
 builder.Services.AddScoped<GoogleUserService>();


### PR DESCRIPTION
## Summary
- register `IHttpContextAccessor` in the service container
- forward auth cookies for the appointments hub connection

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bb828620832b9a0a5b1306ef7f26