### PR TITLE
Use email claim for SignalR user IDs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using Meetify.Hubs;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
 using System.Security.Claims;
 using System.Text;
@@ -24,6 +25,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 builder.Services.AddControllers();
 builder.Services.AddSignalR();
+builder.Services.AddSingleton<IUserIdProvider, EmailUserIdProvider>();
 builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddScoped<SlotService>();

--- a/Services/EmailUserIdProvider.cs
+++ b/Services/EmailUserIdProvider.cs
@@ -1,0 +1,14 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Meetify.Services;
+
+public class EmailUserIdProvider : IUserIdProvider
+{
+    public string? GetUserId(HubConnectionContext connection)
+    {
+        return connection.User?.FindFirst(ClaimTypes.Email)?.Value
+            ?? connection.User?.FindFirst("email")?.Value;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Implement EmailUserIdProvider returning email claim for SignalR connections
- Register custom IUserIdProvider in Program.cs
- SlotService continues to target hub clients by owner's email

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: 403 CONNECT tunnel)*


------
https://chatgpt.com/codex/tasks/task_e_68b5bf3c0f94832ba6879c2dd15a8796