### PR TITLE
Track appointments' share link

### DIFF
--- a/Components/CalendarMonth.razor
+++ b/Components/CalendarMonth.razor
@@ -57,9 +57,18 @@
                                     {
                                         if (IsPublicView)
                                         {
-                                            <span class="badge bg-secondary w-100 text-truncate d-block" title="Obsazeno">
-                                                Obsazeno
-                                            </span>
+                                            if (ev.isCurrent)
+                                            {
+                                                <span class="badge bg-primary w-100 text-truncate d-block" title="@($"Vaše schůzka s {OwnerLabel}")">
+                                                    Vaše schůzka s @OwnerLabel
+                                                </span>
+                                            }
+                                            else
+                                            {
+                                                <span class="badge bg-secondary w-100 text-truncate d-block" title="Obsazeno">
+                                                    Obsazeno
+                                                </span>
+                                            }
                                         }
                                         else
                                         {

--- a/Domain/Appointment.cs
+++ b/Domain/Appointment.cs
@@ -3,14 +3,15 @@
 public class Appointment
 {
 	public int Id { get; set; }
-	public string OwnerUserId { get; set; } = default!; // vlastník kalendáře
-	public DateTime StartUtc { get; set; }
-	public DateTime EndUtc { get; set; }
+        public string OwnerUserId { get; set; } = default!; // vlastník kalendáře
+        public DateTime StartUtc { get; set; }
+        public DateTime EndUtc { get; set; }
+        public Guid ShareLinkId { get; set; }
 
 
 	// Kdo si schůzku domluvil (host)
-	public string GuestFirstName { get; set; } = default!;
-	public string GuestLastName { get; set; } = default!;
+        public string GuestFirstName { get; set; } = default!;
+        public string GuestLastName { get; set; } = default!;
 
 	public DateTime CreatedUtc { get; set; } = DateTime.UtcNow;
 }

--- a/Migrations/20250901120000_AppointmentShareLink.cs
+++ b/Migrations/20250901120000_AppointmentShareLink.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Meetify.Migrations
+{
+    public partial class AppointmentShareLink : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "ShareLinkId",
+                table: "Appointments",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: Guid.Empty);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ShareLinkId",
+                table: "Appointments");
+        }
+    }
+}
+

--- a/Migrations/20250901173738_AppointmentShareLink.Designer.cs
+++ b/Migrations/20250901173738_AppointmentShareLink.Designer.cs
@@ -4,6 +4,7 @@ using Meetify.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Meetify.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250901173738_AppointmentShareLink")]
+    partial class AppointmentShareLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20250901173738_AppointmentShareLink.cs
+++ b/Migrations/20250901173738_AppointmentShareLink.cs
@@ -1,12 +1,14 @@
-using System;
+﻿using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Meetify.Migrations
 {
+    /// <inheritdoc />
     public partial class AppointmentShareLink : Migration
     {
+        /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<Guid>(
@@ -14,9 +16,10 @@ namespace Meetify.Migrations
                 table: "Appointments",
                 type: "uniqueidentifier",
                 nullable: false,
-                defaultValue: Guid.Empty);
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
         }
 
+        /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
@@ -25,4 +28,3 @@ namespace Meetify.Migrations
         }
     }
 }
-

--- a/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -51,6 +51,9 @@ namespace Meetify.Migrations
                     b.Property<DateTime>("StartUtc")
                         .HasColumnType("datetime2");
 
+                    b.Property<Guid>("ShareLinkId")
+                        .HasColumnType("uniqueidentifier");
+
                     b.HasKey("Id");
 
                     b.HasIndex("OwnerUserId", "StartUtc")

--- a/Pages/Schedule.razor
+++ b/Pages/Schedule.razor
@@ -14,7 +14,9 @@
     <CalendarMonth Month="_currentMonth"
                    OwnerUserId="@_link.OwnerUserId"
                    IsPublicView="true"
-                   OnDayClick="OpenDay" 
+                   CurrentShareLinkId="@_link.Id"
+                   OwnerLabel="@OwnerLabel()"
+                   OnDayClick="OpenDay"
                    OnMonthChanged="OnMonthChanged"/>
 }
 

--- a/Services/SlotService.cs
+++ b/Services/SlotService.cs
@@ -158,14 +158,15 @@ public class SlotService
 		if (!FitsWithBuffer(startUtc, endUtc, existing.Select(x => (x.startUtc, x.endUtc))))
 			return (false, "Termín koliduje s jinou schůzkou nebo povinnou pauzou.");
 
-		var appointment = new Appointment
-		{
-			OwnerUserId = ownerUserId,
-			StartUtc = startUtc,
-			EndUtc = endUtc,
-			GuestFirstName = guestFirst.Trim(),
-			GuestLastName = guestLast.Trim()
-		};
+                var appointment = new Appointment
+                {
+                        OwnerUserId = ownerUserId,
+                        StartUtc = startUtc,
+                        EndUtc = endUtc,
+                        GuestFirstName = guestFirst.Trim(),
+                        GuestLastName = guestLast.Trim(),
+                        ShareLinkId = linkId
+                };
 		db.Appointments.Add(appointment);
 
 		// zamknout odkaz (lze rezervovat pouze jednu schůzku tímto linkem)


### PR DESCRIPTION
## Summary
- store the share link identifier on appointments
- highlight the current booking in the calendar view when accessed via a share link
- wire schedule page to pass share link context to calendar

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c858c614832b854159cf92aeeb79